### PR TITLE
Add FPGA Timer/CountDownTimer feature

### DIFF
--- a/generate_project_basys3.tcl
+++ b/generate_project_basys3.tcl
@@ -107,14 +107,15 @@ create_project ${_xil_proj_name_} ./${_xil_proj_name_} -part xc7a35tcpg236-1
 set proj_dir [get_property directory [current_project]]
 
 # Reconstruct message rules
-set_msg_config  -ruleid {1}  -id {Synth 8-3331}  -string {{spi_slave_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {2}  -id {Synth 8-3331}  -string {{i2c_master_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {3}  -id {Synth 8-3331}  -string {{uart_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {4}  -id {Synth 8-3331}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {5}  -id {Synth 8-3331}  -string {{spi_master_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {6}  -id {Synth 8-3917}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {7}  -id {Synth 8-4446}  -string {{mbed_tester_basys3_top}}  -suppress  -source 2
-set_msg_config  -ruleid {8}  -id {Synth 8-4446}  -string {{reprogram_controller}}  -suppress  -source 2
+set_msg_config  -ruleid {1}  -id {Synth 9-3331}  -string {{spi_slave_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {2}  -id {Synth 9-3331}  -string {{i2c_master_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {3}  -id {Synth 9-3331}  -string {{uart_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {4}  -id {Synth 9-3331}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {5}  -id {Synth 9-3331}  -string {{spi_master_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {6}  -id {Synth 9-3331}  -string {{timer_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {7}  -id {Synth 9-3917}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {8}  -id {Synth 9-4446}  -string {{mbed_tester_basys3_top}}  -suppress  -source 2
+set_msg_config  -ruleid {9}  -id {Synth 9-4446}  -string {{reprogram_controller}}  -suppress  -source 2
 
 
 # Set project properties
@@ -177,6 +178,8 @@ set files [list \
  [file normalize "${origin_dir}/rtl/uart_rx.v"] \
  [file normalize "${origin_dir}/rtl/uart_tester_apb2_slave.v"] \
  [file normalize "${origin_dir}/rtl/uart_tx.v"] \
+ [file normalize "${origin_dir}/rtl/timer.v"] \
+ [file normalize "${origin_dir}/rtl/timer_apb2_slave.v"] \
  [file normalize "${origin_dir}/rtl/mbed_tester_basys3_top.v"] \
 ]
 add_files -norecurse -fileset $obj $files
@@ -244,6 +247,8 @@ set files [list \
  [file normalize "${origin_dir}/sim/spi_cs_decoder_tb.v"] \
  [file normalize "${origin_dir}/sim/i2c_master_tester_apb2_slave_tb.v"] \
  [file normalize "${origin_dir}/sim/spi_master_tb.v"] \
+ [file normalize "${origin_dir}/sim/timer_tb.v"] \
+ [file normalize "${origin_dir}/sim/timer_apb2_slave_tb.v"] \
  [file normalize "${origin_dir}/sim/spi_slave_tester_apb2_slave_tb.v"] \
 ]
 add_files -norecurse -fileset $obj $files

--- a/generate_project_shield.tcl
+++ b/generate_project_shield.tcl
@@ -107,14 +107,15 @@ create_project ${_xil_proj_name_} ./${_xil_proj_name_} -part xc7a35tftg256-1
 set proj_dir [get_property directory [current_project]]
 
 # Reconstruct message rules
-set_msg_config  -ruleid {1}  -id {Synth 8-3331}  -string {{spi_slave_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {2}  -id {Synth 8-3331}  -string {{i2c_master_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {3}  -id {Synth 8-3331}  -string {{uart_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {4}  -id {Synth 8-3331}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {5}  -id {Synth 8-3331}  -string {{spi_master_tester_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {6}  -id {Synth 8-3917}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
-set_msg_config  -ruleid {7}  -id {Synth 8-4446}  -string {{mbed_tester_shield_top}}  -suppress  -source 2
-set_msg_config  -ruleid {8}  -id {Synth 8-4446}  -string {{reprogram_controller}}  -suppress  -source 2
+set_msg_config  -ruleid {1}  -id {Synth 9-3331}  -string {{spi_slave_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {2}  -id {Synth 9-3331}  -string {{i2c_master_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {3}  -id {Synth 9-3331}  -string {{uart_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {4}  -id {Synth 9-3331}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {5}  -id {Synth 9-3331}  -string {{spi_master_tester_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {6}  -id {Synth 9-3331}  -string {{timer_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {7}  -id {Synth 9-3917}  -string {{io_metrics_apb2_slave}}  -suppress  -source 2
+set_msg_config  -ruleid {8}  -id {Synth 9-4446}  -string {{mbed_tester_basys3_top}}  -suppress  -source 2
+set_msg_config  -ruleid {9}  -id {Synth 9-4446}  -string {{reprogram_controller}}  -suppress  -source 2
 
 
 # Set project properties
@@ -178,6 +179,8 @@ set files [list \
  [file normalize "${origin_dir}/rtl/uart_rx.v"] \
  [file normalize "${origin_dir}/rtl/uart_tester_apb2_slave.v"] \
  [file normalize "${origin_dir}/rtl/uart_tx.v"] \
+ [file normalize "${origin_dir}/rtl/timer.v"] \
+ [file normalize "${origin_dir}/rtl/timer_apb2_slave.v"] \
  [file normalize "${origin_dir}/rtl/mbed_tester_shield_top.v"] \
 ]
 add_files -norecurse -fileset $obj $files
@@ -244,6 +247,8 @@ set files [list \
  [file normalize "${origin_dir}/sim/uart_tx_tb.v"] \
  [file normalize "${origin_dir}/sim/i2c_master_tester_apb2_slave_tb.v"] \
  [file normalize "${origin_dir}/sim/spi_master_tb.v"] \
+ [file normalize "${origin_dir}/sim/timer_tb.v"] \
+ [file normalize "${origin_dir}/sim/timer_apb2_slave_tb.v"] \
  [file normalize "${origin_dir}/sim/spi_slave_tester_apb2_slave_tb.v"] \
 ]
 add_files -norecurse -fileset $obj $files

--- a/rtl/mbed_tester_peripherals_apb2_slave.v
+++ b/rtl/mbed_tester_peripherals_apb2_slave.v
@@ -38,7 +38,7 @@ module mbed_tester_peripherals_apb2_slave #(
     localparam ADDR_BITS = 20;
     localparam ADDR_LOW_BITS = 12;
     localparam ADDR_HIGH_BITS = ADDR_BITS - ADDR_LOW_BITS;
-    localparam PERIPHERALS = 7;
+    localparam PERIPHERALS = 8;
 
     wire [PERIPHERALS * DATA_BITS - 1:0] PRDATAs;
     wire [PERIPHERALS - 1:0] PSELs;
@@ -83,6 +83,11 @@ module mbed_tester_peripherals_apb2_slave #(
     wire [IO_LOGICAL - 1:0] spi_slave_val;
     wire [IO_LOGICAL - 1:0] spi_slave_drive;
 
+    wire timer_psel;
+    wire [DATA_BITS - 1:0] timer_prdata;
+    wire [IO_LOGICAL - 1:0] timer_val;
+    wire [IO_LOGICAL - 1:0] timer_drive;
+
     genvar i_gen;
 
     assign paddr_low = PADDR[ADDR_LOW_BITS - 1:0];
@@ -95,6 +100,7 @@ module mbed_tester_peripherals_apb2_slave #(
     assign uart_psel = PSELs[4];        // 0x4000
     assign i2c_master_psel = PSELs[5];  // 0x5000
     assign spi_slave_psel = PSELs[6];   // 0x6000
+    assign timer_psel = PSELs[7];       // 0x7000
 
     assign PRDATAs[0 * DATA_BITS+:DATA_BITS] = config_prdata;
     assign PRDATAs[1 * DATA_BITS+:DATA_BITS] = gpio_prdata;
@@ -103,6 +109,7 @@ module mbed_tester_peripherals_apb2_slave #(
     assign PRDATAs[4 * DATA_BITS+:DATA_BITS] = uart_prdata;
     assign PRDATAs[5 * DATA_BITS+:DATA_BITS] = i2c_master_prdata;
     assign PRDATAs[6 * DATA_BITS+:DATA_BITS] = spi_slave_prdata;
+    assign PRDATAs[7 * DATA_BITS+:DATA_BITS] = timer_prdata;
 
     assign logical_val_peripherals[0] = 0;
     assign logical_val_peripherals[1] = gpio_val;
@@ -111,6 +118,7 @@ module mbed_tester_peripherals_apb2_slave #(
     assign logical_val_peripherals[4] = uart_val;
     assign logical_val_peripherals[5] = i2c_master_val;
     assign logical_val_peripherals[6] = spi_slave_val;
+    assign logical_val_peripherals[7] = timer_val;
 
     assign logical_drive_peripherals[0] = 0;
     assign logical_drive_peripherals[1] = gpio_drive;
@@ -119,6 +127,7 @@ module mbed_tester_peripherals_apb2_slave #(
     assign logical_drive_peripherals[4] = uart_drive;
     assign logical_drive_peripherals[5] = i2c_master_drive;
     assign logical_drive_peripherals[6] = spi_slave_drive;
+    assign logical_drive_peripherals[7] = timer_drive;
 
     slave_mux_apb2_slave #(.SELECTOR_BITS(ADDR_HIGH_BITS), .DATA_BITS(DATA_BITS), .SLAVES(PERIPHERALS)) slave_mux_apb2_slave(
         .select(paddr_high),
@@ -256,6 +265,21 @@ module mbed_tester_peripherals_apb2_slave #(
         PWRITE,
         PWDATA,
         spi_slave_prdata
+        );
+
+    // Timer - Offset 0x7000
+    timer_apb2_slave #(.IO_LOGICAL(IO_LOGICAL)) timer_apb2_slave (
+        clk,
+        rst,
+        logical_in,
+        timer_val,
+        timer_drive,
+        paddr_low,
+        timer_psel,
+        PENABLE,
+        PWRITE,
+        PWDATA,
+        timer_prdata
         );
 
 endmodule

--- a/rtl/timer.v
+++ b/rtl/timer.v
@@ -53,7 +53,7 @@ module timer
     localparam MODE_TIMER              = 2'b00;  // Measure elapsed time
     localparam MODE_COUNT_DOWN_TIMER   = 2'b01;  // Perform delay
     
-    reg count_once_reg;
+    reg counting_enabled;
     reg enable_prev;
     wire negedge_enable;
     
@@ -67,18 +67,18 @@ module timer
             // Reset
             if (mode == MODE_TIMER) begin
                 counter <= 0;
-                count_once_reg <= 1;
+                counting_enabled <= 1;
             end else begin
                 counter <= count_down_value;
             end
         end else begin
             if (mode == MODE_TIMER) begin
-                if (enable == 1'b1 && count_once_reg == 1'b1) begin
+                if (enable == 1'b1 && counting_enabled == 1'b1) begin
                     counter <= counter + 1;
                 end
                 
                 if (count_once == 1'b1 && negedge_enable == 1'b1) begin
-                    count_once_reg <= 1'b0;
+                    counting_enabled <= 1'b0;
                 end
                 
             end else begin

--- a/rtl/timer.v
+++ b/rtl/timer.v
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Timer module
+//
+// This module counts elapsed time or performs the delay
+//
+// FPGA Timer resolution is 10 ns: 1 timer tick corresponds to 10 ns.
+//
+// 1. MODE_TIMER
+//    Timer counts `clk` ticks when `enable` signal is high.
+//
+// 1. MODE_COUNT_DOWN_TIMER
+//    Count Down Timer is designed to generate delays. In this mode on reset the
+//    `count_down_value` is loaded to `counter` reg and `delay_pending` signal goes high.
+//    When `enable` becomes high, then Count Down Timer decreases the `counter` reg by 1 on each `clk` raising edge.
+//    When `counter` reg reaches 0, then `delay_pending` goes low indicating that the delay operation is finished.
+//
+// mode - MODE_TIMER: measure elapsed time, MODE_COUNT_DOWN_TIMER: perform delay
+// enable - when 1 Timer counts rising clk edges or perform the delay (depending on mode)
+// count_once - When 1 then only first pulse of the `enable` signal is measured
+// count_down_value - tick count which represents the delay to be performed
+// counter - current counter value
+// delay_pending - a signal which indicates if the programmed delay is still pending
+//
+
+module timer
+    (
+        input wire clk,
+        input wire rst,
+        input wire enable,
+        input wire mode,
+        input wire count_once,
+        input wire[63:0] count_down_value,
+        output reg[63:0] counter,
+        output wire delay_pending
+    );
+
+    localparam MODE_TIMER              = 2'b00;  // Measure elapsed time
+    localparam MODE_COUNT_DOWN_TIMER   = 2'b01;  // Perform delay
+    
+    reg count_once_reg;
+    reg enable_prev;
+    wire negedge_enable;
+    
+    assign delay_pending = (mode == MODE_TIMER ? 0 : (counter == 0 ? 0 : 1));
+    assign negedge_enable = (enable == 1'b0) && (enable_prev == 1'b1);
+
+    // Sequential logic
+    always @(posedge clk) begin
+        enable_prev <= enable;
+        if (rst == 1'b1) begin
+            // Reset
+            if (mode == MODE_TIMER) begin
+                counter <= 0;
+                count_once_reg <= 1;
+            end else begin
+                counter <= count_down_value;
+            end
+        end else begin
+            if (mode == MODE_TIMER) begin
+                if (enable == 1'b1 && count_once_reg == 1'b1) begin
+                    counter <= counter + 1;
+                end
+                
+                if (count_once == 1'b1 && negedge_enable == 1'b1) begin
+                    count_once_reg <= 1'b0;
+                end
+                
+            end else begin
+                if (enable == 1'b1 && counter > 0) begin
+                    counter <= counter - 1;
+                end
+            end
+        end
+    end
+endmodule

--- a/rtl/timer_apb2_slave.v
+++ b/rtl/timer_apb2_slave.v
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Timer/Count Down Timer module
+//
+// This module provides two functions:
+// 1. Timer which counts elapsed time,
+// 2. Count Down Timer which can be used a the delay generator.
+//
+// APB interface:
+// Addr     Size    Name                                                                 Type
+// +0       8       counter                                                              RW
+// +8       8       count_down_value                                                     RW
+// +16      1       ctrl                                                                 WO
+// +17      1       reset request                                                        WO
+//
+module timer_apb2_slave #(
+        parameter IO_LOGICAL = 8
+    )
+    (
+        input wire clk,
+        input wire rst,
+        input wire [IO_LOGICAL - 1:0] logical_in,
+        output wire [IO_LOGICAL - 1:0] logical_val,
+        output wire [IO_LOGICAL - 1:0] logical_drive,
+
+        input wire [ADDR_BITS - 1:0] PADDR,
+        input wire PSEL,
+        input wire PENABLE,
+        input wire PWRITE,
+        input wire [DATA_BITS - 1:0] PWDATA,
+        output reg [DATA_BITS - 1:0] PRDATA
+    );
+
+    localparam ADDR_BITS = 12;
+    localparam DATA_BITS = 8;
+
+    // 0 - FPGA Ticks Counter
+    wire [63:0] counter;
+
+    // 8 - Count Down Value
+    reg [63:0] count_down_value;
+
+    // 16 - Ctrl reg:
+    //        - mode     Ctrl[0]: 0 - Timer, 1 - Count Down Timer
+    //        - one_shot Ctrl[1]: 0 - measure sum of enable pulses, 1 - measure only first enable pulse (only for Timer mode)
+    reg [7:0] ctrl;
+
+    // 17 - Reset request
+    reg [7:0] reset_request;
+
+    reg [63:0] counter_reg;
+
+    wire enable;
+    wire delay_pending;
+    wire reset;
+
+    assign enable = logical_in[0];
+    assign logical_val[0] = 1'b0;
+    assign logical_drive[0] = 0;
+
+    assign logical_val[1] = delay_pending;
+    assign logical_drive[1] = 1;
+
+    // Set unused outputs low
+    assign logical_val[IO_LOGICAL - 1:2] = 0;
+    assign logical_drive[IO_LOGICAL - 1:2] = 0;
+
+    assign reset = ((rst == 1'b1) || (reset_request[0] == 1'b1));
+
+    timer timer (
+        clk,
+        reset,
+        enable,
+        ctrl[0],
+        ctrl[1],
+        count_down_value,
+        counter,
+        delay_pending
+    );
+
+    wire negedge_enable;
+    reg enable_prev;
+
+    assign negedge_enable = (enable == 1'b0) && (enable_prev == 1'b1);
+
+    always @(posedge clk) begin
+        enable_prev <= enable;
+
+        if (reset) begin
+            counter_reg <= 0;
+            reset_request <= 0;
+        end else if (negedge_enable) begin
+            counter_reg <= counter;
+        end
+
+        // APB interface
+        if (PSEL) begin
+            if (PWRITE && PENABLE) begin
+                case (PADDR)
+                    // Writeable values
+                    0: counter_reg[DATA_BITS * 0+:DATA_BITS] <= PWDATA;
+                    1: counter_reg[DATA_BITS * 1+:DATA_BITS] <= PWDATA;
+                    2: counter_reg[DATA_BITS * 2+:DATA_BITS] <= PWDATA;
+                    3: counter_reg[DATA_BITS * 3+:DATA_BITS] <= PWDATA;
+                    4: counter_reg[DATA_BITS * 4+:DATA_BITS] <= PWDATA;
+                    5: counter_reg[DATA_BITS * 5+:DATA_BITS] <= PWDATA;
+                    6: counter_reg[DATA_BITS * 6+:DATA_BITS] <= PWDATA;
+                    7: counter_reg[DATA_BITS * 7+:DATA_BITS] <= PWDATA;
+
+                    8: count_down_value[DATA_BITS * 0+:DATA_BITS] <= PWDATA;
+                    9: count_down_value[DATA_BITS * 1+:DATA_BITS] <= PWDATA;
+                    10: count_down_value[DATA_BITS * 2+:DATA_BITS] <= PWDATA;
+                    11: count_down_value[DATA_BITS * 3+:DATA_BITS] <= PWDATA;
+                    12: count_down_value[DATA_BITS * 4+:DATA_BITS] <= PWDATA;
+                    13: count_down_value[DATA_BITS * 5+:DATA_BITS] <= PWDATA;
+                    14: count_down_value[DATA_BITS * 6+:DATA_BITS] <= PWDATA;
+                    15: count_down_value[DATA_BITS * 7+:DATA_BITS] <= PWDATA;
+
+                    16: ctrl <= PWDATA;
+                    17: reset_request <= PWDATA;
+                    default:;
+                endcase
+            end
+            if (!PWRITE) begin
+
+                case (PADDR)
+                    // Readable values
+                    0: PRDATA <= counter_reg[DATA_BITS * 0+:DATA_BITS];
+                    1: PRDATA <= counter_reg[DATA_BITS * 1+:DATA_BITS];
+                    2: PRDATA <= counter_reg[DATA_BITS * 2+:DATA_BITS];
+                    3: PRDATA <= counter_reg[DATA_BITS * 3+:DATA_BITS];
+                    4: PRDATA <= counter_reg[DATA_BITS * 4+:DATA_BITS];
+                    5: PRDATA <= counter_reg[DATA_BITS * 5+:DATA_BITS];
+                    6: PRDATA <= counter_reg[DATA_BITS * 6+:DATA_BITS];
+                    7: PRDATA <= counter_reg[DATA_BITS * 7+:DATA_BITS];
+
+                    8: PRDATA <= count_down_value[DATA_BITS * 0+:DATA_BITS];
+                    9: PRDATA <= count_down_value[DATA_BITS * 1+:DATA_BITS];
+                    10: PRDATA <= count_down_value[DATA_BITS * 2+:DATA_BITS];
+                    11: PRDATA <= count_down_value[DATA_BITS * 3+:DATA_BITS];
+                    12: PRDATA <= count_down_value[DATA_BITS * 4+:DATA_BITS];
+                    13: PRDATA <= count_down_value[DATA_BITS * 5+:DATA_BITS];
+                    14: PRDATA <= count_down_value[DATA_BITS * 6+:DATA_BITS];
+                    15: PRDATA <= count_down_value[DATA_BITS * 7+:DATA_BITS];
+                    default: PRDATA <= 0;
+                endcase
+            end
+        end
+    end
+endmodule

--- a/sim/build_and_run_timer_apb2_slave_tb.bat
+++ b/sim/build_and_run_timer_apb2_slave_tb.bat
@@ -1,0 +1,19 @@
+::
+:: Copyright (c) 2019, Arm Limited and affiliates.
+:: SPDX-License-Identifier: Apache-2.0
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+:: http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+
+@echo off
+build_and_run_tb.bat timer_apb2_slave_tb

--- a/sim/build_and_run_timer_tb.bat
+++ b/sim/build_and_run_timer_tb.bat
@@ -1,0 +1,19 @@
+::
+:: Copyright (c) 2019, Arm Limited and affiliates.
+:: SPDX-License-Identifier: Apache-2.0
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+:: http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+
+@echo off
+build_and_run_tb.bat timer_tb

--- a/sim/timer_apb2_slave_tb.v
+++ b/sim/timer_apb2_slave_tb.v
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+`include "util.v"
+
+module timer_apb2_slave_tb;
+    parameter ADDR_BITS = 12;
+    parameter DATA_BITS = 8;
+    parameter IO_LOGICAL = 8;
+
+    localparam COUNTER_ADDR = 0;
+    localparam COUNT_DOWN_VALUE_ADDR = 8;
+    localparam CTRL_ADDR = 16;
+
+    reg clk, rst, enable, mode;
+    reg[63:0] counter;
+    wire delay_pending;
+
+    wire [ADDR_BITS - 1:0] PADDR;
+    wire PSEL;
+    wire PENABLE;
+    wire PWRITE;
+    wire [DATA_BITS - 1:0] PWDATA;
+    wire [DATA_BITS - 1:0] PRDATA;
+    wire [IO_LOGICAL - 1:0] logical_in;
+    wire [IO_LOGICAL - 1:0] logical_val;
+    wire [IO_LOGICAL - 1:0] logical_drive;
+
+    assign logical_in = {7'h0, enable};
+
+    assign delay_pending = logical_val[1];
+
+    apb2_slave_tester #(.ADDR_BITS(ADDR_BITS), .DATA_BITS(DATA_BITS)) apb2_slave_tester (
+        .PCLK(clk),
+        .PADDR(PADDR),
+        .PSEL(PSEL),
+        .PENABLE(PENABLE),
+        .PWRITE(PWRITE),
+        .PWDATA(PWDATA),
+        .PRDATA(PRDATA)
+    );
+
+    timer_apb2_slave timer_apb2_slave(
+        .clk(clk),
+        .rst(rst),
+
+        .logical_in(logical_in),
+        .logical_val(logical_val),
+        .logical_drive(logical_drive),
+
+        .PADDR(PADDR),
+        .PSEL(PSEL),
+        .PENABLE(PENABLE),
+        .PWRITE(PWRITE),
+        .PWDATA(PWDATA),
+        .PRDATA(PRDATA)
+    );
+
+    task get_counter;
+        begin
+            apb2_slave_tester.read(COUNTER_ADDR + 0, counter[0 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 1, counter[1 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 2, counter[2 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 3, counter[3 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 4, counter[4 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 5, counter[5 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 6, counter[6 * 8+:8]);
+            apb2_slave_tester.read(COUNTER_ADDR + 7, counter[7 * 8+:8]);
+        end
+    endtask
+
+    task set_delay;
+        input reg[63:0] delay;
+        begin
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 0, delay[0 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 1, delay[1 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 2, delay[2 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 3, delay[3 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 4, delay[4 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 5, delay[5 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 6, delay[6 * 8+:8]);
+            apb2_slave_tester.write(COUNT_DOWN_VALUE_ADDR + 7, delay[7 * 8+:8]);
+        end
+    endtask
+
+    initial begin
+      $dumpfile ("top.vcd");
+      $dumpvars;
+    end
+
+    always begin
+        #5 clk = !clk;
+    end
+
+    initial begin
+        clk = 0;
+
+        // --- Timer Tests ---
+        // -  Multi Count  -
+        set_delay(0);
+        apb2_slave_tester.write(CTRL_ADDR, 0);
+
+        // Timer Reset
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Disabled
+        @(negedge clk);
+        rst = 0;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Enabled
+        @(negedge clk);
+        enable = 1;
+        #(100);
+        @(negedge clk);
+        enable = 0;
+        get_counter();
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Disabled
+        @(negedge clk);
+        #(100);
+        get_counter();
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Enabled
+        @(negedge clk);
+        enable = 1;
+        #(100);
+        @(negedge clk);
+        enable = 0;
+        get_counter();
+        `util_assert_equal(20, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Reset
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // --- Timer Tests ---
+        // -  Single Count  -
+        set_delay(0);
+        apb2_slave_tester.write(CTRL_ADDR, 2);
+
+        // Timer Reset
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Disabled
+        @(negedge clk);
+        rst = 0;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Enabled
+        @(negedge clk);
+        enable = 1;
+        #(100);
+        @(negedge clk);
+        enable = 0;
+        get_counter();
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Disabled
+        @(negedge clk);
+        #(100);
+        get_counter();
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Enabled
+        @(negedge clk);
+        enable = 1;
+        #(100);
+        @(negedge clk);
+        enable = 0;
+        get_counter();
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Reset
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #(100);
+        get_counter();
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // --- Count Down Timer Tests ---
+        set_delay(50);
+        apb2_slave_tester.write(CTRL_ADDR, 1);
+
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #(100);
+        `util_assert_equal(1, delay_pending);
+
+        @(negedge clk);
+        rst = 0;
+        #(100);
+        `util_assert_equal(1, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+        `util_assert_equal(1, delay_pending);
+
+        #(100);
+        `util_assert_equal(1, delay_pending);
+
+        #(400);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 0;
+
+        #(100);
+        $finish;
+
+    end
+
+endmodule

--- a/sim/timer_tb.v
+++ b/sim/timer_tb.v
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+`include "util.v"
+
+module timer_tb;
+    parameter MAIN_CLOCK = 10;
+    reg clk;
+    reg rst;
+    reg enable;
+    reg [7:0] ctrl;
+    wire [63:0] counter;
+    reg [63:0] count_down_value;
+    wire delay_pending;
+
+    timer timer(
+        .clk(clk),
+        .rst(rst),
+        .enable(enable),
+        .mode(ctrl[0]),
+        .count_once(ctrl[1]),
+        .count_down_value(count_down_value),
+        .counter(counter),
+        .delay_pending(delay_pending)
+    );
+
+    initial  begin
+      $dumpfile ("top.vcd");
+      $dumpvars;
+    end
+
+    always
+        #(MAIN_CLOCK/2) clk = !clk;
+
+    initial begin
+        clk = 0;
+
+        // Timer Tests
+        // Multi count
+        count_down_value = 50;
+        ctrl = 8'b00000000;
+
+        @(negedge clk);
+        rst = 1;
+        enable = 1;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 0;
+        enable = 0;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 0;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+        #100;
+        `util_assert_equal(20, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 0;
+        #100;
+        `util_assert_equal(20, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 1;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Timer Tests
+        // Single count
+        count_down_value = 50;
+        ctrl = 8'b00000010;
+
+        @(negedge clk);
+        rst = 1;
+        enable = 1;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 1;
+        enable = 0;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 0;
+        enable = 0;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 0;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        enable = 0;
+        #100;
+        `util_assert_equal(10, counter);
+        `util_assert_equal(0, delay_pending);
+
+        @(negedge clk);
+        rst = 1;
+        #100;
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        // Count Down Timer Tests
+        ctrl = 8'b00000001;
+        count_down_value = 50;
+
+        @(negedge clk);
+        rst = 1;
+        @(negedge clk);
+        rst = 0;
+        `util_assert_equal(50, counter);
+        `util_assert_equal(1, delay_pending);
+
+        #100;
+        `util_assert_equal(50, counter);
+        `util_assert_equal(1, delay_pending);
+
+        @(negedge clk);
+        enable = 1;
+
+        #100
+        `util_assert_equal(40, counter);
+        `util_assert_equal(1, delay_pending);
+
+        #400
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+
+        #100
+        `util_assert_equal(0, counter);
+        `util_assert_equal(0, delay_pending);
+        enable = 0;
+
+        #100 $finish;
+    end
+
+endmodule


### PR DESCRIPTION
This PR adds Verilog implementation for FPGA Timer which can be used in two modes:
- Timer to measure the elapsed time,
- CountDownTimer to generate the programmed delays.

The accuracy of the FPGA Timer is 10 ns: 1 timer tick corresponds to 10 ns.

The mbed OS part of the PR:
https://github.com/ARMmbed/mbed-os/pull/11147