### PR TITLE
UART: Fix the start bit detection

### DIFF
--- a/rtl/uart_rx.v
+++ b/rtl/uart_rx.v
@@ -70,6 +70,7 @@ module uart_rx(
     wire strobe_sample;
     wire strobe_transition;
 
+    reg rx_prev;
     reg [15:0] div_count;
     reg [3:0] bit_count_reg;
     reg [3:0] stop_count_reg;
@@ -84,7 +85,7 @@ module uart_rx(
     integer i;
 
     // Combinational logic
-    assign strobe_start = enable && (state == `STATE_IDLE) && (rx == 0);
+    assign strobe_start = enable && (state == `STATE_IDLE) && (rx_prev == 1'b1) && (rx == 1'b0);
     assign strobe_sample = (state != `STATE_IDLE) && (div_count == div[15:1]);
     assign strobe_transition = (state != `STATE_IDLE) && (div_count == 0);
     assign strobe_done = strobe_done_reg;
@@ -95,6 +96,8 @@ module uart_rx(
 
     // Sequential logic
     always @(posedge clk) begin
+        rx_prev <= rx;
+
         // strobe registers
         strobe_done_reg <= 0;
 

--- a/sim/uart_rx_tb.v
+++ b/sim/uart_rx_tb.v
@@ -527,10 +527,130 @@ module uart_rx_tb;
         end
     endtask
 
+    task start_testcase;
+        begin
+            reset(20);
+
+            @(negedge clk);
+            enable = 0;
+            div = 10;
+            parity_enable = 0;
+            parity_odd_n_even = 0;
+            bit_count = 8;
+            stop_count = 1;
+            rx_manual = 0;
+            rx_manual_n_auto = 1;
+            reset_history();
+
+            // enable while rx=0
+            #10;
+            rx_manual = 0;
+            #10;
+            enable = 1;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=0, then rx=x
+            #10;
+            rx_manual = 0;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 'hx;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=0, then rx=1
+            #10;
+            rx_manual = 0;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 1;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=x
+            #10;
+            rx_manual = 'hx;
+            #10;
+            enable = 1;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=x, then rx=0
+            #10;
+            rx_manual = 'hx;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 0;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=x, then rx=1
+            #10;
+            rx_manual = 'hx;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 1;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=1
+            #10;
+            rx_manual = 1;
+            #10;
+            enable = 1;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=1, then rx=x
+            #10;
+            rx_manual = 1;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 'hx;
+            #10;
+            `util_assert_equal(0, strobe_start_history.events);
+            #10;
+            enable = 0;
+
+            // enable while rx=1, then rx=0; FALLING EDGE -- start bit should be detected
+            #10;
+            rx_manual = 1;
+            #10;
+            enable = 1;
+            #10;
+            rx_manual = 0;
+            #10;
+            `util_assert_equal(1, strobe_start_history.events);
+            #10;
+            enable = 0;
+        end
+    endtask
+
     initial begin
         normal_operation_testcase();
         timing_testcase();
         errors_testcase();
+        start_testcase();
 
         -> terminate_sim;
     end


### PR DESCRIPTION
This PR updates the UART RX module so the start bit is detected only on the falling edge of the RX signal.

Signals form the new test case for comparison:
* before:
![start_bit-old](https://user-images.githubusercontent.com/26014847/63787244-c89f4500-c8f3-11e9-9cac-cae367572017.png)
* after:
![start_bit-new](https://user-images.githubusercontent.com/26014847/63787261-cfc65300-c8f3-11e9-9f63-9462b7b6fcee.png)
